### PR TITLE
Add void * parameter to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 void setup() {
   Serial.begin(115200);
   Wiimote::init();
-  Wiimote::register_callback(1, wiimote_callback);
+  Wiimote::register_callback(1, wiimote_callback, 0);
 }
 
 void loop() {
   Wiimote::handle();
 }
 
-void wiimote_callback(uint8_t number, uint8_t* data, size_t len) {
+void wiimote_callback(uint8_t number, uint8_t* data, size_t len, void *callback_data) {
   Serial.printf("wiimote number=%d len=%d ", number, len);
   if(data[1]==0x32){
     for (int i = 0; i < 4; i++) {

--- a/Wiimote.cpp
+++ b/Wiimote.cpp
@@ -605,8 +605,8 @@ static void process_report(uint8_t* data, uint16_t len){
   // TODO callback[1,2,3]
   uint8_t number = 0;
   wiimote_callback_t cb = wiimote_callback[number];
-  if(cb){
-      cb(number, data, len);
+  if(cb.fun){
+      cb.fun(number, data, len, cb.data);
   }
 }
 
@@ -739,7 +739,7 @@ static void process_hci_event(uint8_t event_code, uint8_t len, uint8_t* data){
 }
 
 void Wiimote::init(){
-  for(int i; i<4; i++){ wiimote_callback[i] = NULL; }
+  for(int i=0; i<4; i++){ wiimote_callback[i].fun = NULL; }
 
   _tx_queue = xQueueCreate(TX_QUEUE_SIZE, sizeof(lendata_t*));
   if (_tx_queue == NULL){
@@ -802,9 +802,10 @@ void Wiimote::handle(){
   }
 }
 
-void Wiimote::register_callback(uint8_t number, wiimote_callback_t cb){
+void Wiimote::register_callback(uint8_t number, wiimote_callback_fun_t cb_fun, void *cb_data){
     if(number < 1 || 4 < number){
         return;
     }
-    wiimote_callback[number-1] = cb;
+    wiimote_callback[number-1].data = cb_data;
+    wiimote_callback[number-1].fun = cb_fun;
 }

--- a/Wiimote.h
+++ b/Wiimote.h
@@ -3,13 +3,18 @@
 
 #include <cstdint>
 
-typedef void (* wiimote_callback_t)(uint8_t number, uint8_t *, size_t);
+typedef void (* wiimote_callback_fun_t)(uint8_t number, uint8_t *, size_t, void *);
+
+typedef struct {
+    wiimote_callback_fun_t fun;
+    void *data;
+} wiimote_callback_t;
 
 class Wiimote {
     public:
         static void init();
         static void handle();
-        static void register_callback(uint8_t number, wiimote_callback_t cb);
+        static void register_callback(uint8_t number, wiimote_callback_fun_t cb, void *data);
 };
 
 #endif


### PR DESCRIPTION
This is a very simple pull request to add a `void *` parameter to the callback function.

It's useful for people who need to update another object from the callback, and don't want to use globals.
